### PR TITLE
modified "change" option to get changed json data

### DIFF
--- a/jquery.jsoneditor.js
+++ b/jquery.jsoneditor.js
@@ -177,7 +177,7 @@
 
             if (!newKey) $(this).parent().remove();
             
-            opt.onchange();
+            opt.onchange(parse(stringify(opt.original)));
         };
     }
 
@@ -200,7 +200,7 @@
 
             updateParents(this, opt);
             
-            opt.onchange();
+            opt.onchange(parse(stringify(opt.original)));
         };
     }
     

--- a/jsoneditor.js
+++ b/jsoneditor.js
@@ -16,6 +16,12 @@ function printJSON() {
 
 }
 
+function updateJSON(data) {
+    json = data;
+    printJSON();
+
+}
+
 $(document).ready(function() {
 
     $('#rest > button').click(function() {
@@ -26,7 +32,7 @@ $(document).ready(function() {
             jsonp: $('#rest-callback').val(),
             success: function(data) {
                 json = data;
-                $('#editor').jsonEditor(json, { change: printJSON });
+                $('#editor').jsonEditor(json, { change: updateJSON });
                 printJSON();
             },
             error: function() {
@@ -45,7 +51,7 @@ $(document).ready(function() {
             json = {};
         }
         
-        $('#editor').jsonEditor(json, { change: printJSON });
+        $('#editor').jsonEditor(json, { change: updateJSON });
     });
 
     $('#expander').click(function() {
@@ -55,7 +61,7 @@ $(document).ready(function() {
     });
     
     printJSON();
-    $('#editor').jsonEditor(json, { change: printJSON });
+    $('#editor').jsonEditor(json, { change: updateJSON });
 });
 
 


### PR DESCRIPTION
Because the data has beed `stringify`ed and `parse`ed when init to strip down non-JSON data types. So the original json data won't changed whenever you access.

The new usage just like:

``` javascript
$('#editor').jsonEditor(json, { change: function (jsonChanged) {...} });
```

Another thing should be noticed is that I tried very hard but didn't find your way to minify the code. so the `jquery.jsoneditor.min.js` hasn't been updated.

Hope to be useful.
Thanks.
